### PR TITLE
Allow for search criteria save during screen change

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -15,6 +15,18 @@ import axios from 'axios';
 
 function App() {
   const [allPokemon, setAllPokemon] = useState([]);
+  const [searchString, setSearchString] = useState("");
+  const [typeFilter, setTypeFilter] = useState(new Set());
+  const [weaknessFilter, setWeaknessFilter] = useState(new Set());
+  const searchPkg = {
+    searchString,
+    setSearchString,
+    typeFilter, 
+    setTypeFilter,
+    weaknessFilter, 
+    setWeaknessFilter,
+  }
+
 
   //fetch all pokemon at the top level for all sub-components to share
   useEffect(() =>{
@@ -36,7 +48,7 @@ function App() {
       <Router>
         <Routes>
           <Route path={"/:num"} element={<ViewPokemonDetails allPokemon={allPokemon}/>} />
-          <Route strict path="/" element={<PokeTable allPokemon={allPokemon}/>} />
+          <Route strict path="/" element={<PokeTable allPokemon={allPokemon} searchPkg={searchPkg} />} />
         </Routes>
       </Router>
     </div>

--- a/src/views/PokeTable.jsx
+++ b/src/views/PokeTable.jsx
@@ -10,11 +10,8 @@ import axios from 'axios';
 const types = ["Normal", "Fire", "Water", "Grass", "Electric", "Ice", "Fighting", "Poison", "Ground", "Flying", "Psychic", "Bug", "Rock", "Ghost"];
 
 
-function PokeTable({allPokemon}) {
+function PokeTable({allPokemon, searchPkg: {searchString, weaknessFilter, typeFilter, setSearchString, setWeaknessFilter, setTypeFilter}}) {
   const [pokemon, setPokemon] = useState([]);
-  const [searchString, setSearchString] = useState("");
-  const [typeFilter, setTypeFilter] = useState(new Set());
-  const [weaknessFilter, setWeaknessFilter] = useState(new Set());
   const [showFilters, setShowFilters] = useState(true);
 
   useEffect(() => {


### PR DESCRIPTION
State variables managing the search criteria were moved up a level to 'App' in order to hold search criteria through routed view changes. 

The App component passes it's newly acquired state variables and their setters to the PokeTable component via a bundled prop object called 'SearchPkg'

'SearchPkg' is then de-structured in the argument list of the PokeTable component into named variables & functions which are used and modified throughout the PokeTable component.